### PR TITLE
Fix false-positive Vercel OAuth connections in Electron

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -481,9 +481,26 @@ function handleDeepLink(url) {
     if (host === 'vercel' && path === '/callback') {
       const code  = parsed.searchParams.get('code');
       const state = parsed.searchParams.get('state');
+      const oauthError = parsed.searchParams.get('error');
+      const oauthErrorDescription = parsed.searchParams.get('error_description');
+
+      if (oauthError) {
+        const message = oauthErrorDescription
+          ? `Vercel OAuth failed: ${oauthErrorDescription}`
+          : `Vercel OAuth failed: ${oauthError}`;
+        console.error('[electron] vercel oauth callback error:', message);
+        if (mainWindow) {
+          mainWindow.webContents.send('vercel:oauth-error', message);
+        }
+        return;
+      }
 
       if (!code || !state) {
-        console.warn('[electron] kua://vercel/callback missing code or state');
+        const message = 'Vercel OAuth callback missing code or state';
+        console.warn(`[electron] ${message}`);
+        if (mainWindow) {
+          mainWindow.webContents.send('vercel:oauth-error', message);
+        }
         return;
       }
 
@@ -493,7 +510,17 @@ function handleDeepLink(url) {
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify({ code, state }),
       })
-        .then(r => r.json())
+        .then(async (response) => {
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            const message = data?.error || `OAuth callback failed (${response.status})`;
+            throw new Error(message);
+          }
+          if (!data?.id || !data?.name) {
+            throw new Error('OAuth callback returned invalid profile data');
+          }
+          return data;
+        })
         .then(data => {
           if (mainWindow) {
             // Notify the renderer so it can refresh its profile list and

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -650,6 +650,10 @@ async function handleConnectionSave(payload) {
 
   // Vercel OAuth flow: profile already created by backend callback, just select it
   if (payload.oauthProfile && payload.provider === 'vercel') {
+    if (!payload.oauthProfile.id || !payload.oauthProfile.name) {
+      toast('Vercel OAuth failed: invalid callback response', 'error')
+      return
+    }
     modals.addConnection = false
     await envStore.fetchProfiles()
     vercelProfileId.value = payload.oauthProfile.id

--- a/frontend/src/components/modals/ProfileModal.vue
+++ b/frontend/src/components/modals/ProfileModal.vue
@@ -181,6 +181,7 @@
                   <svg width="14" height="12" viewBox="0 0 76 65" fill="currentColor"><path d="M37.5274 0L75.0548 65H0L37.5274 0Z"/></svg>
                   {{ oauthPending ? 'Waiting for authorization…' : 'Connect with Vercel' }}
                 </button>
+                <span v-if="oauthErrorMsg" class="text-red" style="font-size:12px">{{ oauthErrorMsg }}</span>
                 <div style="display:flex;align-items:center;gap:8px;font-size:11px;color:var(--text-dim)">
                   <hr style="flex:1;border-color:var(--border)" />
                   or enter token manually
@@ -497,10 +498,12 @@ function submit() {
 // ── Vercel OAuth ───────────────────────────────────────────────────────────────
 const isElectron   = typeof window !== 'undefined' && !!window.kuaElectron
 const oauthPending = ref(false)
+const oauthErrorMsg = ref('')
 let oauthHandlers  = []
 
 function startVercelOAuth() {
   if (!window.kuaElectron?.startVercelOAuth) return
+  oauthErrorMsg.value = ''
   oauthPending.value = true
   const name = form.value.name.trim() || 'Vercel'
   window.kuaElectron.startVercelOAuth(name)
@@ -511,6 +514,7 @@ onMounted(() => {
 
   const successHandler = window.kuaElectron.onVercelOAuthComplete?.((profile) => {
     oauthPending.value = false
+    oauthErrorMsg.value = ''
     // Emit save with the profile returned by the backend OAuth callback
     // App.vue treats this as a "select existing profile" event
     emit('save', { oauthProfile: profile, provider: 'vercel' })
@@ -519,7 +523,7 @@ onMounted(() => {
 
   const errorHandler = window.kuaElectron.onVercelOAuthError?.((msg) => {
     oauthPending.value = false
-    console.error('[ProfileModal] Vercel OAuth error:', msg)
+    oauthErrorMsg.value = msg || 'Vercel OAuth failed'
   })
 
   if (successHandler) oauthHandlers.push(['vercel:oauth-complete', successHandler])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuadashboard",
-  "version": "1.9.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuadashboard",
-      "version": "1.9.1",
+      "version": "1.10.2",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.1032.0",
         "@aws-sdk/client-apigatewayv2": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuadashboard",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Simple Kubernetes Admin Dashboard - Lens-like web UI",
   "author": {
     "name": "lnavarrocarter",


### PR DESCRIPTION
The Vercel connection flow could report success even when OAuth callback exchange failed, leaving users with a broken or unclear connection state. This change makes the OAuth result handling strict so the UI only completes when a valid profile is actually created.

## What changed
- In `electron/main.js`, deep-link callback handling now:
  - surfaces OAuth provider errors (`error`, `error_description`) to the renderer,
  - treats missing `code`/`state` as a user-visible error,
  - validates backend callback responses and only emits `vercel:oauth-complete` when `{ id, name }` is present.
- In `ProfileModal.vue`, OAuth errors are shown inline in the Vercel connect section instead of only logging to console.
- In `App.vue`, added a guard to reject invalid OAuth profile payloads and show an error toast.

## Notes for reviewers
This is intentionally behavior-tightening: success events are now blocked unless callback data is valid, which prevents false-positive "connected" states after failed OAuth exchanges.