### PR TITLE
Fix freeze when opening Step Functions diagram for state machines with loops

### DIFF
--- a/frontend/src/components/StepFnDiagram.vue
+++ b/frontend/src/components/StepFnDiagram.vue
@@ -288,13 +288,21 @@ const layout = computed(() => {
   if (!parsed.value || !parsed.value.States) return { nodes: [], edges: [], startAt: '', pos: {} }
   const { StartAt, States } = parsed.value
 
-  // BFS to assign deepest level
+  // BFS to assign deepest level (longest path from StartAt).
+  // Step Functions definitions can contain cycles (e.g. Wait/retry polling
+  // loops), which would make this relaxation loop run forever. Cap the
+  // number of times a node can be re-queued so cyclic graphs still
+  // terminate instead of freezing the UI.
+  const totalStates = Object.keys(States).length
   const level = {}
+  const visitCount = {}
   const queue = [{ name: StartAt, lvl: 0 }]
   level[StartAt] = 0
 
   while (queue.length) {
     const { name, lvl } = queue.shift()
+    visitCount[name] = (visitCount[name] || 0) + 1
+    if (visitCount[name] > totalStates) continue // cycle guard
     const state = States[name]
     if (!state) continue
     for (const { name: next } of getNexts(state)) {


### PR DESCRIPTION
## Summary
- Fixes a UI freeze ("se queda pegada") when opening the **Diagrama** tab for a Step Functions state machine whose ASL definition contains a cycle (e.g. a Wait/retry polling loop).
- Reproduced with profile `dev`, state machine `afex-piloto-dev-singleCall`, which has the loop `ValidateConcurrency -> ConcurrencyOk -> Delay -> ValidateConcurrency`.
- Root cause: the BFS in `StepFnDiagram.vue` assigns each node the *longest path* level from `StartAt` by re-queuing a node whenever a longer path to it is found. On a cyclic graph this relaxation never converges — the `while` loop runs forever and blocks the renderer's main thread, freezing the whole app (Electron is single-process).
- Fix: cap how many times a node can be re-queued (bounded by total state count), so the loop always terminates even when the definition has cycles.

## Test plan
- [x] Confirmed `afex-piloto-dev-singleCall` (profile `dev`) has a cycle via the backend API (`GET /stepfunctions/config`).
- [x] Simulated the original algorithm against this definition — confirmed it loops indefinitely.
- [x] Simulated the patched algorithm against the same definition — confirmed it now terminates (50 iterations) and produces valid levels.
- [x] `npm run build --prefix frontend` succeeds with no errors.
- [x] Manual check in the running app: open AWS > Step Functions > `afex-piloto-dev-singleCall` > Diagrama tab and confirm it renders without freezing.